### PR TITLE
Add fallback resolve for when </head> is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ const fetchHead = async (url) => {
           resolve(head)
         }
       }
+
+      resolve(head)
     })
 
   /*if (!global.fetch) {


### PR DESCRIPTION
Addresses https://github.com/luisivan/fetch-meta-tags/issues/1

The problem was that Twitter returns a malformed HTML document that contains no `head` tags or closing `body` tag - [here's the validator output](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Ftwitter.com%2FJungleSilicon) for the URL from the issue. This meant the `resolve` was never called with the head of the document as it's inside a conditional.

I went for the simplest option and just resolved the entire returned HTML document as a fallback.