### PR TITLE
Add second parameter requestInit to fetchMeta function

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I wanted a way to quickly fetch OG tags from websites and get their title, descr
 
 `fetch-meta-tags` solves those problems by:
 
-- Having just two dependencies: `node-fetch` and `node-html-parser`. They are both very lightweight libraries and also very fast
+- Having just one dependency: `node-html-parser`. Very lightweight library and also very fast
 - Streaming websites and stopping the HTTP request once `</head>` is received. No need to fetch the whole HTML of the website
 
 ## Installation
@@ -27,12 +27,24 @@ $ yarn add fetch-meta-tags
 $ npm install --save fetch-meta-tags
 ```
 
+For Typescript project you can also use the types package:
+
+```sh
+$ yarn add fetch-meta-tags @types/fetch-meta-tags
+```
+
+```sh
+$ npm install --save fetch-meta-tags @types/fetch-meta-tags
+```
+
 ## Usage
 
 ```js
 import fetchMeta from 'fetch-meta-tags'
 
 await fetchMeta('https://luisc.xyz')
+
+await fetchMeta('https://luisc.xyz', { method: 'GET', cache: 'no-cache' })
 ```
 
 Outputs:

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser'
 
 import metadataRuleSets from './rulesets.js'
 
-const fetchHead = async (url) => {
+const fetchHead = async (url, requestInit) => {
   const read = async (body) =>
     new Promise(async (resolve) => {
       let head = ''
@@ -18,18 +18,15 @@ const fetchHead = async (url) => {
       resolve(head)
     })
 
-  /*if (!global.fetch) {
-    global.fetch = await import('node-fetch')
-  }*/
-  const res = await fetch(url)
+  const res = await fetch(url, requestInit)
   return read(res.body)
 }
 
 const makeUrlAbsolute = (url, path) =>
   new URL(path, new URL(url).origin).toString()
 
-export default async function fetchMeta(url) {
-  const head = await fetchHead(url)
+export default async function fetchMeta(url, requestInit = {}) {
+  const head = await fetchHead(url, requestInit)
   const dom = parse(head)
   const metadata = {
     url,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-meta-tags",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Fetch and parse OG tags and metadata from any URL, the fast way",
   "exports": "./index.js",
   "type": "module",
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/luisivan/fetch-meta-tags#readme",
   "dependencies": {
-    "node-fetch": "^3.0.0",
     "node-html-parser": "^5.0.0"
   }
 }


### PR DESCRIPTION
The PR adds a second parameter to provide extra options to the `fetch` call.
A useless lib `node-fetch` is also removed since it was not used.